### PR TITLE
Reformatting dashboard

### DIFF
--- a/Richmond_Library_App/templates/home.html
+++ b/Richmond_Library_App/templates/home.html
@@ -5,28 +5,103 @@
 {% endblock %}
 
 {% block app_block %}
-  <div class="container">
-  <!-- Display books -->
-    <div class="container">
-      <h1>Book Dashboard</h1>
-      <div class="book-container">
-        {% for book in books %}
-        {% comment %} sets book card to be a clickable link via book title {% endcomment %}
-        <a href="{% url 'Book' bookname=book.title %}">
-        <div class="book-card">
-          <img class="book-image" src="{{ book.image.url }}" alt="{{ book.title }} Cover">
-          <div class="book-info">
-            <h3>{{ book.title }}</h3>
-            <p>Author: {{ book.author }}</p>
-            <p>Publisher: {{ book.publisher }}</p>
-            <p>Copies: {{ book.copies }}</p>
-            <p>Available: {{ book.available }}</p>
-            <!-- end of book desciptions but can add more later on if needed -->
+<div class="container">
+  <div class="intro-image-container">
+    <!-- Currently have a AI image as the stand-in; should replace in the future --> 
+    <img class="intro-image" src="{% static 'images/library_photo.jpg' %}" alt="MPS Library Introduction">
+    <div class="intro-text">MPS Library</div>
+  </div>
+
+  <div style="margin-top: 50px;"></div> 
+
+  <h1 style="color: #215FAC;">Fiction</h1>
+  <div id="bookCarouselF" class="carousel slide" data-bs-ride="carousel">
+    <div class="carousel-inner">
+      <div class="carousel-item active">
+        <div class="row">
+          {% for book in books %}
+          <div class="col-md-4">
+            <a href="{% url 'Book' bookname=book.title %}">
+              <div class="book-card">
+                <img class="book-image" src="{{ book.image.url }}" alt="{{ book.title }} Cover">
+                <div class="book-info">
+                  <h3>{{ book.title }}</h3>
+                  <p>Author: {{ book.author }}</p>
+                  <p>Publisher: {{ book.publisher }}</p>
+                  <p>Copies: {{ book.copies }}</p>
+                  <p>Available: {{ book.available }}</p>
+                </div>
+              </div>
+            </a>
           </div>
+          {% if forloop.counter|divisibleby:3 and not forloop.last %}
         </div>
-      </a>
-        {% endfor %}
+      </div>
+      <div class="carousel-item{% if forloop.last %} active{% endif %}">
+        <div class="row">
+          {% endif %}
+          {% endfor %}
+        </div>
       </div>
     </div>
+    <a class="carousel-control-prev" href="#bookCarouselF" role="button" data-bs-slide="prev" style="left: -50px;">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="visually-hidden">Previous</span>
+    </a>
+    <a class="carousel-control-next" href="#bookCarouselF" role="button" data-bs-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="visually-hidden">Next</span>
+    </a>
   </div>
+
+  <div style="margin-top: 50px;"></div> 
+
+  <h1 style="color: #215FAC;">Non-fiction</h1>
+  <div id="bookCarouselNF" class="carousel slide" data-bs-ride="carousel">
+    <div class="carousel-inner">
+      <div class="carousel-item active">
+        <div class="row">
+          {% for book in books %}
+          <div class="col-md-4">
+            <a href="{% url 'Book' bookname=book.title %}">
+              <div class="book-card">
+                <img class="book-image" src="{{ book.image.url }}" alt="{{ book.title }} Cover">
+                <div class="book-info">
+                  <h3>{{ book.title }}</h3>
+                  <p>Author: {{ book.author }}</p>
+                  <p>Publisher: {{ book.publisher }}</p>
+                  <p>Copies: {{ book.copies }}</p>
+                  <p>Available: {{ book.available }}</p>
+                </div>
+              </div>
+            </a>
+          </div>
+          {% if forloop.counter|divisibleby:3 and not forloop.last %}
+        </div>
+      </div>
+      <div class="carousel-item{% if forloop.last %} active{% endif %}">
+        <div class="row">
+          {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+    <a class="carousel-control-prev" href="#bookCarouselNF" role="button" data-bs-slide="prev" style="left: -50px;">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="visually-hidden">Previous</span>
+    </a>
+    <a class="carousel-control-next" href="#bookCarouselNF" role="button" data-bs-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="visually-hidden">Next</span>
+    </a>
+  </div>
+
+  <div style="margin-top: 100px;"></div> 
+
+  <!-- Link doesn't work because we don't have a books page, change this when page is made -->
+  <div class="view-all-books-link">
+    <a href="/view-all-books">View All Books</a>
+  </div>
+
+</div>
 {% endblock %}

--- a/static/home.css
+++ b/static/home.css
@@ -1,5 +1,5 @@
 body {
-    background-color: #215fac;
+    background-color: #d9d9d9;
 }
 
 /* 215FAC, blue*/
@@ -50,4 +50,70 @@ body {
 
 .book-card:hover .book-info {
   opacity: 1;
+}
+
+.carousel-control-prev,
+.carousel-control-next {
+  width: 40px; /* Adjust the width as needed */
+  height: 40px; /* Adjust the height as needed */
+  top: 50%; /* Adjust the vertical position as needed */
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.2); /* Adjust the background color and opacity as needed */
+  border: none; /* Remove the border */
+  border-radius: 50%; /* Create a circular hitbox */
+}
+
+.carousel-control-prev-icon,
+.carousel-control-next-icon {
+  width: 20px; /* Adjust the width to match the arrow size */
+  height: 20px; /* Adjust the height to match the arrow size */
+  /* background-image: url('path-to-your-arrow-image.png');  Optionally, use a custom arrow image */
+  background-size: cover; /* Adjust the background size as needed */
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+/* Optionally, you can style the arrows when hovered */
+.carousel-control-prev:hover,
+.carousel-control-next:hover {
+  background: rgba(255, 255, 255, 0.2); /* Adjust the hover background color and opacity as needed */
+}
+
+/* Style for the introductory image container */
+.intro-image-container {
+  position: relative;
+  text-align: center;
+}
+
+/* Style for the introductory image */
+.intro-image {
+  width: 100%; /* Adjust the width as needed */
+  height: 35%; /* Adjust the width as needed */
+}
+
+/* Style for the text overlay with a shadow */
+.intro-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #ffffff; /* Text color */
+  font-size: 3em; /* Use em units for responsive font size */
+  text-shadow: 5px 5px 10px rgba(0, 0, 0, 1); /* Shadow effect */
+}
+
+/* Style for the link */
+.view-all-books-link {
+  text-align: center;
+  margin-top: 20px;
+}
+
+.view-all-books-link a {
+ display: inline-block;
+ background-color: #215FAC;
+ color: white;
+ padding: 10px 20px;
+ border-radius: 5px;
+ text-decoration: none;
+ font-size: 18px;
 }


### PR DESCRIPTION
Updated the webpage to include an opening image (which is switchable once we get a real photo) as well as the text "MPS Library" in the middle of the image. Also added book carousels; I was only able to add two because past two, the formatting of the books was different. The spacing between the 3rd+ was larger and typically went to each end of the page. If we want more just let me know and I'll try to take another crack at it. Most of the formatting is editable, and there's comments on what does what if it needs to be changed. At the end of the page is a button link to all the books and the search, but because we don't have a page like that, the link just leads to an error page. Once we have something like that, the page link can just be added in. If I'm wrong and we won't have something like that then it should be pretty easy to just delete.